### PR TITLE
Don't spam output log with primaryKeyToIdKey messages

### DIFF
--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -119,8 +119,9 @@ class TokuOplogTool : public Tool {
                     // Copied from OplogHelpers::runUpdateModsWithRowWithLock
                     // mongo/db/oplog_helpers.cpp:569 in tokumx version from github.com/7segments/mongo
                     // mongo/db/oplog_helpers.cpp:546 in tokumx version from this repo
+                    BSONObj oldRowObj = oldRow.Obj(); // need to keep this in variable as it has to outlive modSet
                     scoped_ptr<ModSet> modSet(new ModSet(mods, emptyIndexPathSet));
-                    auto_ptr<ModSetState> mss = modSet->prepare(oldRow.Obj());
+                    auto_ptr<ModSetState> mss = modSet->prepare(oldRowObj);
                     BSONObj newObj = mss->createNewFromMods();
                     _conn->update(ns_str, id, newObj, true, false);
                 } else {

--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -134,7 +134,7 @@ class TokuOplogTool : public Tool {
             vector<std::string> params;
             boost::split(params, param, boost::is_any_of(":"));
             if (params.size() % 2 != 0) {
-                log() << "--renameDatabase requires even number of parts"
+                log() << "--renameDatabase requires even number of parts" << endl;
                 return -1;
             }
             for (size_t i = 0; i + 1 < params.size(); i += 2) {

--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -79,7 +79,7 @@ class TokuOplogTool : public Tool {
             }
             if (_migrateEventsCollection && ns.coll == "events") {
                 const BSONObj obj = op[OplogHelpers::KEY_STR_ROW].Obj();
-                if (op["company_id"].type() != String) {
+                if (obj["company_id"].type() != String) {
                     error() << "invalid or missing company_id in events op" << endl;
                     return false;
                 }
@@ -229,7 +229,7 @@ class TokuOplogTool : public Tool {
 
                 while (running && r.more()) {
                     BSONObj o = r.nextSafe();
-                    LOG(2) << o << endl;
+                    LOG(3) << o << endl;
 
                     if (needsGTIDCheck) {
                         GTID gtid = getGTIDFromBSON("_id", o);

--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -100,6 +100,9 @@ class TokuOplogTool : public Tool {
                     return false;
                 }
                 string company_id = obj["company_id"].valuestr();
+                if (_onlyProject.size() > 0 && _onlyProject != company_id) {
+                    continue;
+                }
                 std::replace(company_id.begin(), company_id.end(), '-', '_');
                 ns.coll = "events_" + company_id;
                 ns_str = ns.ns();
@@ -404,6 +407,7 @@ class TokuOplogTool : public Tool {
     string _rpass;
     string _rauthenticationDatabase;
     string _rauthenticationMechanism;
+    string _onlyProject;
     bool _migrateEventsCollection;
     map<string, string> _renameDatabase;
     unordered_set<string> _ignore;
@@ -423,6 +427,7 @@ public:
         ("from", po::value<string>() , "host to pull from" )
         ("renameDatabase", po::value<string>() , "rename database" )
         ("migrateEventsCollection", po::value<bool>(&_migrateEventsCollection) , "migrate events" )
+        ("onlyProject", po::value<string>(&onlyProject) , "only process events for a single project" )
         ("ignore", po::value<string>() , "comma separated list of ns to ignore" )
         ("only", po::value<string>() , "comma separated list of ns to process, ignore the rest" )
         ("ruser", po::value<string>(), "username on source host if auth required" )

--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -151,6 +151,11 @@ class TokuOplogTool : public Tool {
                 LOG(2) << "cmd: " << ns_str << endl;
                 BSONObj info = _conn->findOne(ns_str, cmd);
                 if (!info["ok"].trueValue()) {
+                    if (!cmd["create"].eoo() && info["code"].numberInt() == 48) {
+                        // we are trying to create a collection, but the collection already exists
+                        // so ignore the error
+                        continue;
+                    }
                     error() << "error replaying command op " << op << ": " << info << endl;
                     return false;
                 }

--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -133,6 +133,10 @@ class TokuOplogTool : public Tool {
             string param = getParam("renameDatabase");
             vector<std::string> params;
             boost::split(params, param, boost::is_any_of(":"));
+            if (params.size() % 2 != 0) {
+                log() << "--renameDatabase requires even number of parts"
+                return -1;
+            }
             for (size_t i = 0; i + 1 < params.size(); i += 2) {
                 _renameDatabase[params[i]] = params[i + 1];
             }

--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -93,6 +93,15 @@ class TokuOplogTool : public Tool {
                 ns.db = newDbIt->second;
                 ns_str = ns.ns();
             }
+            if (_onlyProject.size() > 0) {
+                const BSONObj obj = op[OplogHelpers::KEY_STR_ROW].Obj();
+                if (obj["company_id"].type() == String) {
+                    string company_id = obj["company_id"].valuestr();
+                    if (_onlyProject != company_id) {
+                        continue;
+                    }
+                }
+            }
             if (_migrateEventsCollection && ns.coll == "events") {
                 const BSONObj obj = op[OplogHelpers::KEY_STR_ROW].Obj();
                 if (obj["company_id"].type() != String) {
@@ -100,9 +109,6 @@ class TokuOplogTool : public Tool {
                     return false;
                 }
                 string company_id = obj["company_id"].valuestr();
-                if (_onlyProject.size() > 0 && _onlyProject != company_id) {
-                    continue;
-                }
                 std::replace(company_id.begin(), company_id.end(), '-', '_');
                 ns.coll = "events_" + company_id;
                 ns_str = ns.ns();
@@ -427,7 +433,7 @@ public:
         ("from", po::value<string>() , "host to pull from" )
         ("renameDatabase", po::value<string>() , "rename database" )
         ("migrateEventsCollection", po::value<bool>(&_migrateEventsCollection) , "migrate events" )
-        ("onlyProject", po::value<string>(&onlyProject) , "only process events for a single project" )
+        ("onlyProject", po::value<string>(&_onlyProject) , "only process docs for a single project (be careful about using this, it only handles a few specific collections)" )
         ("ignore", po::value<string>() , "comma separated list of ns to ignore" )
         ("only", po::value<string>() , "comma separated list of ns to process, ignore the rest" )
         ("ruser", po::value<string>(), "username on source host if auth required" )

--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -89,18 +89,22 @@ class TokuOplogTool : public Tool {
             }
             string ns_str = ns.ns();
             if (type == OplogHelpers::OP_STR_INSERT || type == OplogHelpers::OP_STR_CAPPED_INSERT) {
+                LOG(2) << "insert: " << ns_str << endl;
                 const BSONObj obj = op[OplogHelpers::KEY_STR_ROW].Obj();
                 _conn->insert(ns_str, obj);
             } else if (type == OplogHelpers::OP_STR_UPDATE) {
+                LOG(2) << "remove/insert: " << ns_str << endl;
                 const BSONObj oldObj = op[OplogHelpers::KEY_STR_OLD_ROW].Obj();
                 const BSONObj newObj = op[OplogHelpers::KEY_STR_NEW_ROW].Obj();
                 _conn->remove(ns_str, oldObj, true);
                 _conn->insert(ns_str, newObj);
             } else if (type == OplogHelpers::OP_STR_UPDATE_ROW_WITH_MOD) {
+                LOG(2) << "update: " << ns_str << endl;
                 const BSONObj id = primaryKeyToIdKey(op[OplogHelpers::KEY_STR_PK].Obj());
                 const BSONObj mods = op[OplogHelpers::KEY_STR_MODS].Obj();
                 _conn->update(ns_str, id, mods);
             } else if (type == OplogHelpers::OP_STR_DELETE || type == OplogHelpers::OP_STR_CAPPED_DELETE) {
+                LOG(2) << "remove: " << ns_str << endl;
                 const BSONObj obj = op[OplogHelpers::KEY_STR_ROW].Obj();
                 _conn->remove(ns_str, obj);
             } else if (type == OplogHelpers::OP_STR_COMMAND) {
@@ -109,6 +113,7 @@ class TokuOplogTool : public Tool {
                     error() << "invalid command op " << op << endl;
                     return false;
                 }
+                LOG(2) << "cmd: " << ns_str << endl;
                 BSONObj info = _conn->findOne(ns_str, cmd);
                 if (!info["ok"].trueValue()) {
                     error() << "error replaying command op " << op << ": " << info << endl;

--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -54,7 +54,7 @@ class TokuOplogTool : public Tool {
             e = *it;
         }
         BSONObj o = BSON("_id" << e);
-        log() << "primaryKeyToIdKey: pk = " << pk << ", o = " << o << endl;
+        LOG(2) << "primaryKeyToIdKey: pk = " << pk << ", o = " << o << endl;
         return o;
     }
 

--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -94,11 +94,14 @@ class TokuOplogTool : public Tool {
                 ns_str = ns.ns();
             }
             if (_onlyProject.size() > 0) {
-                const BSONObj obj = op[OplogHelpers::KEY_STR_ROW].Obj();
-                if (obj["company_id"].type() == String) {
-                    string company_id = obj["company_id"].valuestr();
-                    if (_onlyProject != company_id) {
-                        continue;
+                const BSONElement elem = op[OplogHelpers::KEY_STR_ROW];
+                if (elem.isABSONObj()) {
+                    const BSONObj obj = elem.Obj();
+                    if (obj["company_id"].type() == String) {
+                        string company_id = obj["company_id"].valuestr();
+                        if (_onlyProject != company_id) {
+                            continue;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Running toku2mongo currently generates a lot of data on stdout, because every primary key to _id is logged. Ideally, these messages should be only logged in verbose mode.
