### PR TITLE
Toku2mongo 2.0.3

### DIFF
--- a/src/mongo/tools/toku2mongo.cpp
+++ b/src/mongo/tools/toku2mongo.cpp
@@ -76,10 +76,9 @@ class TokuOplogTool : public Tool {
                 const BSONObj obj = op[OplogHelpers::KEY_STR_ROW].Obj();
                 _conn->insert(ns, obj);
             } else if (type == OplogHelpers::OP_STR_UPDATE) {
-                const BSONObj oldObj = op[OplogHelpers::KEY_STR_OLD_ROW].Obj();
+                const BSONObj id = primaryKeyToIdKey(op[OplogHelpers::KEY_STR_PK].Obj());
                 const BSONObj newObj = op[OplogHelpers::KEY_STR_NEW_ROW].Obj();
-                _conn->remove(ns, oldObj, true);
-                _conn->insert(ns, newObj);
+                _conn->update(ns, id, newObj, true, false);
             } else if (type == OplogHelpers::OP_STR_UPDATE_ROW_WITH_MOD) {
                 const BSONObj id = primaryKeyToIdKey(op[OplogHelpers::KEY_STR_PK].Obj());
                 const BSONObj mods = op[OplogHelpers::KEY_STR_MODS].Obj();

--- a/src/mongo/util/version.cpp
+++ b/src/mongo/util/version.cpp
@@ -48,7 +48,7 @@ namespace mongo {
      * If you really need to do something else you'll need to fix _versionArray()
      */
     const char mongodbVersionString[] = "2.4.10";
-    const char tokumxVersionString[] = "2.0.2";
+    const char tokumxVersionString[] = "2.0.2-upsert";
 
     std::string fullVersionString() {
         stringstream ss;

--- a/src/mongo/util/version.cpp
+++ b/src/mongo/util/version.cpp
@@ -48,7 +48,7 @@ namespace mongo {
      * If you really need to do something else you'll need to fix _versionArray()
      */
     const char mongodbVersionString[] = "2.4.10";
-    const char tokumxVersionString[] = "2.0.2-upsert";
+    const char tokumxVersionString[] = "2.0.3";
 
     std::string fullVersionString() {
         stringstream ss;


### PR DESCRIPTION
Customer reported issue with duplicate record insert failure.   It was determined that the remove/insert was failing (document was not being removed from migration target).   Replacing the remove/insert combination with an upsert instruction was tested and verified by Percona Services.